### PR TITLE
docs: add getContrastRatio documentation and playground

### DIFF
--- a/public/playground/getContrastRatio.html
+++ b/public/playground/getContrastRatio.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>getContrastRatio</title>
+    <style>
+      body {
+        color: #fff;
+        margin: 0;
+        font-family: Courier New;
+      }
+      label {
+        display: block;
+        font-size: 1.25rem;
+        margin-bottom: 0.5em;
+      }
+      button {
+        border-image: conic-gradient(
+          from 85deg at 56% 145%,
+          #ff4700 49% 49%,
+          #829fff 99% 99%
+        );
+        background-color: transparent;
+        border-image-slice: 1;
+        border-width: 5px;
+        color: #fff;
+        font-size: 1.125rem;
+        margin-bottom: 1em;
+        padding: 5px 10px;
+      }
+      .input {
+        border: 4px solid #fff;
+        box-sizing: border-box;
+        font-family: Courier New;
+        font-size: 1.25rem;
+        padding: 0.25rem 0.75rem;
+        margin-bottom: 1em;
+        width: 100%;
+        &:focus-visible {
+          border-image-slice: 1;
+          border-image-source: conic-gradient(
+            from 85deg at 56% 145%,
+            #ff4700 49% 49%,
+            #829fff 99% 99%
+          );
+        }
+        &:focus {
+          outline: none;
+        }
+      }
+      #result {
+        padding: 0.5em;
+        font-size: 1.5rem;
+      }
+    </style>
+    <script type="module">
+      import { getContrastRatio } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+
+      function convertOnSubmit(input) {
+        try {
+          const colours = input.split(",").map((c) => c.trim());
+          if (colours.length !== 2) {
+            throw new Error("Please provide two colours separated by a comma");
+          }
+          const res = getContrastRatio(colours[0], colours[1], "WCAG2.1");
+          document.getElementById("result").innerHTML = res;
+        } catch (error) {
+          document.getElementById("result").innerHTML = error;
+        }
+      }
+
+      window.convertOnSubmit = convertOnSubmit;
+    </script>
+  </head>
+  <body>
+    <label for="input">Type two colours separated by a comma</label>
+    <input
+      type="text"
+      id="input"
+      class="input"
+      placeholder="#ffffff, #000000"
+    />
+    <button
+      type="button"
+      onclick="convertOnSubmit(document.getElementById('input').value)"
+    >
+      Convert
+    </button>
+    <label id="result"></label>
+  </body>
+</html>

--- a/src/docs/getContrastRatio.md
+++ b/src/docs/getContrastRatio.md
@@ -1,0 +1,155 @@
+---
+title: Get contrast ratio
+description: Calculate the contrast ratio between two colours according to WCAG standards.
+code: true
+tags: utility functions
+---
+
+# getContrastRatio
+
+The `getContrastRatio` function calculates the contrast ratio between two colours according to the Web Content Accessibility Guidelines (WCAG). It supports multiple colour formats including hex, CSS RGB, and named CSS colours, making it versatile for accessibility testing and compliance.
+
+> **Added in:** @sardine/colour@2.2.0
+
+## Signature
+
+```typescript
+getContrastRatio(
+  colour1: string | NamedCSSColour,
+  colour2: string | NamedCSSColour,
+  standard: "WCAG2.1" | "WCAG3.0"
+): number
+```
+
+### Parameters
+
+- `colour1` - The first colour for comparison (hex, CSS RGB, or named CSS colour)
+- `colour2` - The second colour for comparison (hex, CSS RGB, or named CSS colour)
+- `standard` - The WCAG standard to use (`"WCAG2.1"` or `"WCAG3.0"`)
+
+### Returns
+
+Returns the contrast ratio as a number, truncated to 3 decimal places. Values range from 1 (identical colours) to 21 (pure black and white).
+
+## Examples
+
+### Hex Colours
+
+```javascript
+import { getContrastRatio } from "@sardine/colour";
+
+// Black text on white background
+const ratio = getContrastRatio("#000000", "#ffffff", "WCAG2.1");
+console.log(ratio); // 21
+
+// Red text on white background
+const redOnWhite = getContrastRatio("#ff0000", "#ffffff", "WCAG2.1");
+console.log(redOnWhite); // 3.998
+```
+
+### CSS RGB Colours
+
+```javascript
+import { getContrastRatio } from "@sardine/colour";
+
+// Standard CSS RGB syntax
+const ratio1 = getContrastRatio(
+  "rgb(255, 255, 255)",
+  "rgb(0, 0, 0)",
+  "WCAG2.1"
+);
+console.log(ratio1); // 21
+
+// Modern space-separated syntax
+const ratio2 = getContrastRatio("rgb(255 255 255)", "rgb(0 0 0)", "WCAG2.1");
+console.log(ratio2); // 21
+
+// With percentage values
+const ratio3 = getContrastRatio(
+  "rgb(100%, 100%, 100%)",
+  "rgb(0%, 0%, 0%)",
+  "WCAG2.1"
+);
+console.log(ratio3); // 21
+```
+
+### Named CSS Colours
+
+```javascript
+import { getContrastRatio } from "@sardine/colour";
+
+// Using named colours
+const ratio = getContrastRatio("white", "black", "WCAG2.1");
+console.log(ratio); // 21
+
+// Blue text on white background
+const blueOnWhite = getContrastRatio("blue", "white", "WCAG2.1");
+console.log(blueOnWhite); // 8.592
+```
+
+### Mixed Formats
+
+```javascript
+import { getContrastRatio } from "@sardine/colour";
+
+// Mixing different colour formats
+const ratio1 = getContrastRatio("#ffffff", "rgb(0, 0, 0)", "WCAG2.1");
+console.log(ratio1); // 21
+
+const ratio2 = getContrastRatio("white", "#000000", "WCAG2.1");
+console.log(ratio2); // 21
+```
+
+## WCAG Standards
+
+The function supports both WCAG 2.1 and WCAG 3.0 standards:
+
+- **"WCAG2.1"**: Standard contrast requirements (4.5:1 for normal text, 3:1 for large text)
+- **"WCAG3.0"**: Enhanced contrast calculation with improved color space handling
+
+```javascript
+import { getContrastRatio } from "@sardine/colour";
+
+const colour1 = "#767676";
+const colour2 = "#ffffff";
+
+// Check against both standards
+const ratioWCAG21 = getContrastRatio(colour1, colour2, "WCAG2.1");
+const ratioWCAG30 = getContrastRatio(colour1, colour2, "WCAG3.0");
+
+console.log(`WCAG 2.1: ${ratioWCAG21}`); // WCAG 2.1: 4.54
+console.log(`WCAG 3.0: ${ratioWCAG30}`); // WCAG 3.0: 4.54
+```
+
+## Error Handling
+
+The function throws an error for invalid colour formats:
+
+```javascript
+import { getContrastRatio } from "@sardine/colour";
+
+try {
+  getContrastRatio("invalid", "#ffffff", "WCAG2.1");
+} catch (error) {
+  console.log(error); // "Invalid colour format: invalid"
+}
+
+try {
+  getContrastRatio("#ffffff", "not-a-colour", "WCAG2.1");
+} catch (error) {
+  console.log(error); // "Invalid colour format: not-a-colour"
+}
+```
+
+## Interactive Demo
+
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/getContrastRatio.html"
+  title="getContrastRatio"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>


### PR DESCRIPTION
## Description

Add comprehensive documentation for the `getContrastRatio` function from the `@sardine/colour` library.

## What's included

- **Complete function documentation** with TypeScript signature and parameter descriptions
- **Multiple code examples** covering:
  - Hex colours (`#ffffff`, `#000000`)
  - CSS RGB colours with various syntaxes (`rgb(255, 255, 255)`, `rgb(255 255 255)`, `rgb(100%, 100%, 100%)`)
  - Named CSS colours (`white`, `black`, `blue`)
  - Mixed format combinations
- **WCAG standards support** documentation for both `"WCAG2.1"` and `"WCAG3.0"`
- **Error handling examples** with real error messages
- **Interactive playground demo** for real-time testing
- **Version information** noting the function was added in @sardine/colour@2.2.0

## Key features documented

✅ Multiple colour format support (hex, CSS RGB, named CSS colours)  
✅ WCAG 2.1 and WCAG 3.0 standard compliance  
✅ Proper TypeScript type definitions  
✅ Comprehensive error handling  
✅ Interactive playground with minimal styling  
✅ Accessibility-focused examples and use cases  

## Testing completed

- [x] Documentation renders correctly in dev server
- [x] Interactive playground works without errors
- [x] Function examples are accurate and tested
- [x] Navigation automatically includes new function
- [x] All code examples use correct WCAG string literal syntax
- [x] Error handling matches actual library behavior

## Progress update

This completes issue #65 and updates the main tracking issue progress to **18/34 functions documented (53%)**.

Closes #65