### PR TITLE
docs: add Find Nearest Hexadecimal Colour documentation and playground

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,12 @@
 # GitHub Copilot Instructions for colour.sardine.dev
 
+### Additional Documentation Details (AI Agent Notes)
+
+- Always use the full word "hexadecimal" instead of "hex" in documentation titles, descriptions, and content.
+- The "> **Added in:**" version note must appear immediately after the frontmatter block.
+- Use a "## Description" section (not a function name heading) to introduce the function, matching the style of other documentation files.
+- Playground files must be created in `src/pages/playground` using the PlaygroundLayout template and Astro named slots.
+
 This document provides essential guidance for AI coding agents working on this documentation website for the `@sardine/colour` JavaScript utility library.
 
 ## Project Overview

--- a/src/docs/findNearestHexColour.md
+++ b/src/docs/findNearestHexColour.md
@@ -1,0 +1,57 @@
+---
+title: Find Nearest Hexadecimal Colour
+code: true
+tags: utility functions
+description: Finds the nearest hexadecimal colour in a palette to a given hexadecimal colour.
+---
+
+> **Added in:** @sardine/colour@2.1.0
+
+## Description
+
+Finds the nearest hexadecimal colour in a palette to the given hexadecimal colour.
+
+## Signature
+
+```typescript
+function findNearestHexColour(colour: string, palette: string[]): string
+```
+
+## Parameters
+- `colour`: `string` — The hexadecimal colour to find the nearest match for (e.g., `"#ff0000"`).
+- `palette`: `string[]` — An array of hexadecimal colours to search for the nearest match in.
+
+## Returns
+- `string` — The hexadecimal colour in the palette that is closest to the given colour. If the palette has fewer than 2 colours, or is undefined/null, the original colour is returned.
+
+## Examples
+
+```typescript
+import { findNearestHexColour } from "@sardine/colour";
+
+findNearestHexColour("#ff0000", ["#00ff00", "#0000ff", "#f80000"]);
+// => "#f80000"
+
+findNearestHexColour("#123456", ["#654321"]);
+// => "#123456" (palette too small)
+
+findNearestHexColour("#abcdef", undefined);
+// => "#abcdef" (palette is undefined)
+```
+
+## Error Handling
+
+- If `palette` is not an array or has fewer than 2 colours, the function returns the input colour.
+- If `colour` is not a valid hexadecimal string, downstream conversion functions may throw errors (e.g., `convertHextoRGB`).
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/findNearestHexColour.html"
+  title="findNearestHexColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/pages/playground/findNearestHexColour.astro
+++ b/src/pages/playground/findNearestHexColour.astro
@@ -1,0 +1,41 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Find Nearest Hexadecimal Colour">
+  <script slot="script" is:inline type="module">
+    import { findNearestHexColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+
+    function convertOnSubmit() {
+      const input = document.getElementById("inputColour").value;
+      const palette = document
+        .getElementById("inputPalette")
+        .value.split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      try {
+        const res = findNearestHexColour(input, palette);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = res;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+
+  <div slot="body">
+    <label for="inputColour">Type a colour in the hexadecimal format</label>
+    <input type="text" id="inputColour" class="input" placeholder="#ff0000" />
+    <label for="inputPalette">Palette (comma-separated hexadecimal)</label>
+    <input
+      type="text"
+      id="inputPalette"
+      class="input"
+      placeholder="#00ff00,#0000ff,#f80000"
+    />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>


### PR DESCRIPTION
This pull request introduces improvements to the documentation and an interactive playground for the `findNearestHexColour` function in the `@sardine/colour` library. The most important changes include adding detailed documentation, creating a corresponding playground file, and updating guidelines for writing documentation.

### Documentation Updates:
* Added a new documentation file `src/docs/findNearestHexColour.md` with detailed information about the `findNearestHexColour` function, including its signature, parameters, return value, examples, error handling, and an embedded interactive demo.
* Updated `.github/copilot-instructions.md` to include additional guidelines for documentation, such as using the full word "hexadecimal" and specifying the structure for function descriptions and playground files.

### Interactive Playground:
* Created a new playground file `src/pages/playground/findNearestHexColour.astro` to provide an interactive demo for the `findNearestHexColour` function, allowing users to input colours and palettes and see the results in real-time.- Add comprehensive documentation for findNearestHexadecimalColour function
- Include function signature, parameters, return type, and examples
- Add interactive playground demo with real-time conversion
- Update copilot-instructions with new documentation standards
- Proper error handling documentation

Closes #62