### PR TITLE
docs: add convertXYZtoRGB documentation and playground

### DIFF
--- a/src/docs/convertXYZtoRGB.md
+++ b/src/docs/convertXYZtoRGB.md
@@ -1,0 +1,44 @@
+---
+title: Convert XYZ to RGB
+code: true
+tags: converters
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+The `convertXYZtoRGB` function converts a colour from the CIE XYZ colour space to an RGB object. It expects an object with `X`, `Y`, and `Z` properties.
+
+## Signature
+
+```typescript
+function convertXYZtoRGB(colour: XYZColour): RGBColour;
+```
+
+## Example
+
+```javascript
+import { convertXYZtoRGB } from "@sardine/colour";
+
+const xyzColour = {
+  X: 20.517540535826125,
+  Y: 21.586050011389926,
+  Z: 23.50720846240363
+};
+const rgbColour = convertXYZtoRGB(xyzColour);
+console.log(rgbColour);
+/* expects
+{
+  R: 81,
+  G: 90,
+  B: 74,
+}
+*/
+```
+
+## Interactive Demo
+
+Try the function yourself with our interactive playground:
+
+<iframe src="/playground/convertXYZtoRGB.html" title="convertXYZtoRGB" width="100%" height="500px" style="border:0; overflow:hidden;" sandbox="allow-scripts allow-same-origin"></iframe>

--- a/src/pages/playground/convertXYZtoRGB.astro
+++ b/src/pages/playground/convertXYZtoRGB.astro
@@ -1,0 +1,33 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="convertXYZtoRGB">
+  <script slot="script" is:inline type="module">
+    import { convertXYZtoRGB } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+
+    function convertOnSubmit(input) {
+      try {
+        const numbers = input.split(',').map((n) => parseFloat(n.trim()));
+        if (numbers.length !== 3 || numbers.some((n) => isNaN(n))) {
+          throw new Error('Please provide three numbers separated by commas');
+        }
+        const colour = { X: numbers[0], Y: numbers[1], Z: numbers[2] };
+        const res = convertXYZtoRGB(colour);
+        document.getElementById('result').innerHTML = JSON.stringify(res);
+        document.getElementById('result').style.backgroundColor = `rgb(${res.R}, ${res.G}, ${res.B})`;
+      } catch (error) {
+        document.getElementById('result').innerHTML = error;
+      }
+    }
+
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+
+  <div slot="body">
+    <label for="input">Type XYZ values separated by commas</label>
+    <input type="text" id="input" class="input" placeholder="20.5, 21.5, 23.5" />
+    <button type="button" onclick="convertOnSubmit(document.getElementById('input').value)">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>


### PR DESCRIPTION
## Summary
- add `convertXYZtoRGB` documentation
- create interactive playground for `convertXYZtoRGB`

## Testing
- `npm run build`

Closes #61

------
https://chatgpt.com/codex/tasks/task_e_6885156fdc488331a6d0cd5541397a69