### PR TITLE
docs: add Get Contrast Ratio From CSSRGB documentation and playground

### DIFF
--- a/src/docs/getContrastRatioFromCSSRGB.md
+++ b/src/docs/getContrastRatioFromCSSRGB.md
@@ -1,0 +1,55 @@
+---
+title: Get Contrast Ratio From CSSRGB
+code: true
+tags: utility functions
+description: Calculates the contrast ratio between two colours in CSSRGB format.
+---
+
+> **Added in:** @sardine/colour@2.2.0
+
+## Description
+
+Calculates the contrast ratio between two colours in CSSRGB format, using the specified WCAG standard.
+
+## Signature
+
+```typescript
+function getContrastRatioFromCSSRGB(colour1: string, colour2: string, standard: WCAG): number
+```
+
+## Parameters
+- `colour1`: `string` — The first colour in CSSRGB format (e.g., `"rgb(255,0,0)"`).
+- `colour2`: `string` — The second colour in CSSRGB format (e.g., `"rgb(0,255,0)"`).
+- `standard`: `WCAG` — The WCAG standard to evaluate the contrast ratio against (e.g., `"WCAG2.1"`).
+
+## Returns
+- `number` — The contrast ratio between the two colours, truncated to 3 decimal places.
+
+## Examples
+
+```typescript
+import { getContrastRatioFromCSSRGB } from "@sardine/colour";
+
+getContrastRatioFromCSSRGB("rgb(255,0,0)", "rgb(0,255,0)", "WCAG2.1");
+// => 1.284
+
+getContrastRatioFromCSSRGB("rgb(0,0,0)", "rgb(255,255,255)", "WCAG2.1");
+// => 21
+```
+
+## Error Handling
+
+- If either colour is not a valid CSSRGB string, the function may throw an error from `convertCSSRGBtoRGB`.
+- If the standard is not a valid WCAG value, the function may throw an error from downstream functions.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/getContrastRatioFromCSSRGB.html"
+  title="getContrastRatioFromCSSRGB"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/pages/playground/getContrastRatioFromCSSRGB.astro
+++ b/src/pages/playground/getContrastRatioFromCSSRGB.astro
@@ -1,0 +1,34 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Get Contrast Ratio From CSSRGB">
+  <script slot="script" is:inline type="module">
+    import { getContrastRatioFromCSSRGB } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+
+    function convertOnSubmit() {
+      const colour1 = document.getElementById("inputColour1").value;
+      const colour2 = document.getElementById("inputColour2").value;
+      const standard = document.getElementById("inputStandard").value;
+      try {
+        const res = getContrastRatioFromCSSRGB(colour1, colour2, standard);
+        document.getElementById("result").innerHTML = res;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+
+  <div slot="body">
+    <label for="inputColour1">First colour (CSSRGB format)</label>
+    <input type="text" id="inputColour1" class="input" placeholder="rgb(255,0,0)" />
+    <label for="inputColour2">Second colour (CSSRGB format)</label>
+    <input type="text" id="inputColour2" class="input" placeholder="rgb(0,255,0)" />
+    <label for="inputStandard">WCAG Standard</label>
+    <input type="text" id="inputStandard" class="input" placeholder="WCAG2.1" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>


### PR DESCRIPTION
- Add comprehensive documentation for getContrastRatioFromCSSRGB function
- Include function signature, parameters, return type, and examples
- Add interactive playground demo with real-time conversion
- Proper error handling documentation

Closes #66