### PR TITLE
docs: add missing documentation and playgrounds for utility functions

### DIFF
--- a/src/docs/getContrastRatioFromNamedCSSColour.md
+++ b/src/docs/getContrastRatioFromNamedCSSColour.md
@@ -1,0 +1,51 @@
+---
+title: Get Contrast Ratio From Named CSS Colour
+code: true
+tags: utility functions
+description: Calculates the contrast ratio between two named CSS colours using the specified WCAG standard.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Calculates the contrast ratio between two named CSS colours according to the specified WCAG standard.
+
+## Signature
+
+```typescript
+function getContrastRatioFromNamedCSSColour(colour1: string, colour2: string, standard?: WCAG): number
+```
+
+## Parameters
+- `colour1`: `string` — The first named CSS colour (e.g., `"navy"`).
+- `colour2`: `string` — The second named CSS colour (e.g., `"yellow"`).
+- `standard`: `WCAG` (optional) — The WCAG standard to use (e.g., `"WCAG2.1"`).
+
+## Returns
+- `number` — The contrast ratio value.
+
+## Examples
+
+```typescript
+import { getContrastRatioFromNamedCSSColour } from "@sardine/colour";
+
+getContrastRatioFromNamedCSSColour("navy", "yellow", "WCAG2.1");
+// => 15.3
+```
+
+## Error Handling
+
+- Throws an error if either input is not a valid named CSS colour.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/getContrastRatioFromNamedCSSColour.html"
+  title="getContrastRatioFromNamedCSSColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/getSRGBLuminanceFromHex.md
+++ b/src/docs/getSRGBLuminanceFromHex.md
@@ -1,0 +1,49 @@
+---
+title: Get sRGB Luminance From Hexadecimal
+code: true
+tags: utility functions
+description: Calculates the sRGB luminance value from a hexadecimal colour.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Calculates the sRGB luminance value for a given hexadecimal colour string.
+
+## Signature
+
+```typescript
+function getSRGBLuminanceFromHex(hex: string): number
+```
+
+## Parameters
+- `hex`: `string` — The hexadecimal colour string (e.g., `"#222429"`).
+
+## Returns
+- `number` — The sRGB luminance value (0 to 1).
+
+## Examples
+
+```typescript
+import { getSRGBLuminanceFromHex } from "@sardine/colour";
+
+getSRGBLuminanceFromHex("#222429");
+// => 0.052
+```
+
+## Error Handling
+
+- Throws an error if the input is not a valid hexadecimal colour string.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/getSRGBLuminanceFromHex.html"
+  title="getSRGBLuminanceFromHex"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/getSRGBLuminanceFromRGB.md
+++ b/src/docs/getSRGBLuminanceFromRGB.md
@@ -1,0 +1,49 @@
+---
+title: Get sRGB Luminance From RGB
+code: true
+tags: utility functions
+description: Calculates the sRGB luminance value from an RGB colour.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Calculates the sRGB luminance value for a given RGB colour object.
+
+## Signature
+
+```typescript
+function getSRGBLuminanceFromRGB(rgb: RGB): number
+```
+
+## Parameters
+- `rgb`: `RGB` — The RGB colour object (e.g., `{ r: 34, g: 36, b: 41 }`).
+
+## Returns
+- `number` — The sRGB luminance value (0 to 1).
+
+## Examples
+
+```typescript
+import { getSRGBLuminanceFromRGB } from "@sardine/colour";
+
+getSRGBLuminanceFromRGB({ r: 34, g: 36, b: 41 });
+// => 0.052
+```
+
+## Error Handling
+
+- Throws an error if the input is not a valid RGB object.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/getSRGBLuminanceFromRGB.html"
+  title="getSRGBLuminanceFromRGB"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/isCSSNamedDarkColour.md
+++ b/src/docs/isCSSNamedDarkColour.md
@@ -1,5 +1,5 @@
 ---
-title: Is CSS Named Dark Colour
+title: Is Named CSS Colour Dark
 code: true
 tags: utility functions
 description: Determines if a named CSS colour is considered dark.

--- a/src/docs/isCSSNamedDarkColour.md
+++ b/src/docs/isCSSNamedDarkColour.md
@@ -1,0 +1,52 @@
+---
+title: Is CSS Named Dark Colour
+code: true
+tags: utility functions
+description: Determines if a named CSS colour is considered dark.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Checks if a named CSS colour string represents a dark colour based on luminance.
+
+## Signature
+
+```typescript
+function isCSSNamedDarkColour(name: string): boolean
+```
+
+## Parameters
+- `name`: `string` — The named CSS colour (e.g., `"navy"`).
+
+## Returns
+- `boolean` — `true` if the colour is dark, otherwise `false`.
+
+## Examples
+
+```typescript
+import { isCSSNamedDarkColour } from "@sardine/colour";
+
+isCSSNamedDarkColour("navy");
+// => true
+
+isCSSNamedDarkColour("yellow");
+// => false
+```
+
+## Error Handling
+
+- Throws an error if the input is not a valid named CSS colour.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/isCSSNamedDarkColour.html"
+  title="isCSSNamedDarkColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/isCSSRGBColour.md
+++ b/src/docs/isCSSRGBColour.md
@@ -1,0 +1,55 @@
+---
+title: Is CSS RGB Colour
+code: true
+tags: utility functions
+description: Validates if a string is a proper CSS RGB colour.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Checks if a given string is a valid CSS RGB colour format.
+
+## Signature
+
+```typescript
+function isCSSRGBColour(cssRGB: string): boolean
+```
+
+## Parameters
+- `cssRGB`: `string` — The string to validate (e.g., `"rgb(255, 224, 0)"`).
+
+## Returns
+- `boolean` — `true` if the string is a valid CSS RGB colour, otherwise `false`.
+
+## Examples
+
+```typescript
+import { isCSSRGBColour } from "@sardine/colour";
+
+isCSSRGBColour("rgb(255, 224, 0)");
+// => true
+
+isCSSRGBColour("rgb(34, 36, 41)");
+// => true
+
+isCSSRGBColour("not-a-colour");
+// => false
+```
+
+## Error Handling
+
+- Returns `false` for invalid input; does not throw errors.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/isCSSRGBColour.html"
+  title="isCSSRGBColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/isCSSRGBDarkColour.md
+++ b/src/docs/isCSSRGBDarkColour.md
@@ -1,0 +1,52 @@
+---
+title: Is CSS RGB Dark Colour
+code: true
+tags: utility functions
+description: Determines if a CSS RGB colour string is considered dark.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Checks if a CSS RGB colour string represents a dark colour based on luminance.
+
+## Signature
+
+```typescript
+function isCSSRGBDarkColour(cssRGB: string): boolean
+```
+
+## Parameters
+- `cssRGB`: `string` — The CSS RGB colour string (e.g., `"rgb(34, 36, 41)"`).
+
+## Returns
+- `boolean` — `true` if the colour is dark, otherwise `false`.
+
+## Examples
+
+```typescript
+import { isCSSRGBDarkColour } from "@sardine/colour";
+
+isCSSRGBDarkColour("rgb(34, 36, 41)");
+// => true
+
+isCSSRGBDarkColour("rgb(255, 224, 0)");
+// => false
+```
+
+## Error Handling
+
+- Throws an error if the input is not a valid CSS RGB colour string.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/isCSSRGBDarkColour.html"
+  title="isCSSRGBDarkColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/isDarkColour.md
+++ b/src/docs/isDarkColour.md
@@ -1,0 +1,55 @@
+---
+title: Is Dark Colour
+code: true
+tags: utility functions
+description: Determines if a colour (hexadecimal, RGB, or CSS RGB) is considered dark.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Checks if a colour in various formats is considered dark based on luminance.
+
+## Signature
+
+```typescript
+function isDarkColour(colour: string | RGB | CSSRGB): boolean
+```
+
+## Parameters
+- `colour`: `string | RGB | CSSRGB` — The colour to check (hexadecimal, RGB object, or CSS RGB string).
+
+## Returns
+- `boolean` — `true` if the colour is dark, otherwise `false`.
+
+## Examples
+
+```typescript
+import { isDarkColour } from "@sardine/colour";
+
+isDarkColour("#222429");
+// => true
+
+isDarkColour({ r: 255, g: 224, b: 0 });
+// => false
+
+isDarkColour("rgb(34, 36, 41)");
+// => true
+```
+
+## Error Handling
+
+- Throws an error if the input is not a valid colour format.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/isDarkColour.html"
+  title="isDarkColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/isHexColour.md
+++ b/src/docs/isHexColour.md
@@ -1,0 +1,52 @@
+---
+title: Is Hexadecimal Colour
+code: true
+tags: utility functions
+description: Validates if a string is a proper hexadecimal colour.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Checks if a given string is a valid hexadecimal colour format.
+
+## Signature
+
+```typescript
+function isHexColour(hex: string): boolean
+```
+
+## Parameters
+- `hex`: `string` — The string to validate (e.g., `"#ffe000"`).
+
+## Returns
+- `boolean` — `true` if the string is a valid hexadecimal colour, otherwise `false`.
+
+## Examples
+
+```typescript
+import { isHexColour } from "@sardine/colour";
+
+isHexColour("#ffe000");
+// => true
+
+isHexColour("#xyz123");
+// => false
+```
+
+## Error Handling
+
+- Returns `false` for invalid input; does not throw errors.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/isHexColour.html"
+  title="isHexColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/docs/isHexDarkColour.md
+++ b/src/docs/isHexDarkColour.md
@@ -1,0 +1,52 @@
+---
+title: Is Hexadecimal Dark Colour
+code: true
+tags: utility functions
+description: Determines if a hexadecimal colour is considered dark.
+---
+
+> **Added in:** @sardine/colour@1.2.0
+
+## Description
+
+Checks if a given hexadecimal colour string represents a dark colour based on luminance.
+
+## Signature
+
+```typescript
+function isHexDarkColour(hex: string): boolean
+```
+
+## Parameters
+- `hex`: `string` — The hexadecimal colour string (e.g., `"#222429"`).
+
+## Returns
+- `boolean` — `true` if the colour is dark, otherwise `false`.
+
+## Examples
+
+```typescript
+import { isHexDarkColour } from "@sardine/colour";
+
+isHexDarkColour("#222429");
+// => true
+
+isHexDarkColour("#ffe000");
+// => false
+```
+
+## Error Handling
+
+- If the input is not a valid hexadecimal colour, the function may throw an error.
+
+## Interactive Demo
+Try the function yourself with our interactive playground:
+
+<iframe
+  src="/playground/isHexDarkColour.html"
+  title="isHexDarkColour"
+  width="100%"
+  height="500px"
+  style="border:0; overflow:hidden;"
+  sandbox="allow-scripts allow-same-origin"
+></iframe>

--- a/src/pages/playground/getContrastRatioFromNamedCSSColour.astro
+++ b/src/pages/playground/getContrastRatioFromNamedCSSColour.astro
@@ -1,0 +1,31 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Get Contrast Ratio From Named CSS Colour">
+  <script slot="script" is:inline type="module">
+    import { getContrastRatioFromNamedCSSColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const colour1 = document.getElementById("inputColour1").value;
+      const colour2 = document.getElementById("inputColour2").value;
+      const standard = document.getElementById("inputStandard").value;
+      try {
+        const res = getContrastRatioFromNamedCSSColour(colour1, colour2, standard);
+        document.getElementById("result").innerHTML = res;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="inputColour1">First named CSS colour</label>
+    <input type="text" id="inputColour1" class="input" placeholder="navy" />
+    <label for="inputColour2">Second named CSS colour</label>
+    <input type="text" id="inputColour2" class="input" placeholder="yellow" />
+    <label for="inputStandard">WCAG standard</label>
+    <input type="text" id="inputStandard" class="input" placeholder="WCAG2.1" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/getSRGBLuminanceFromHex.astro
+++ b/src/pages/playground/getSRGBLuminanceFromHex.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Get sRGB Luminance From Hexadecimal">
+  <script slot="script" is:inline type="module">
+    import { getSRGBLuminanceFromHex } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const hex = document.getElementById("input").value;
+      try {
+        const res = getSRGBLuminanceFromHex(hex);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = hex;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type a colour in the hexadecimal format</label>
+    <input type="text" id="input" class="input" placeholder="#222429" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/getSRGBLuminanceFromRGB.astro
+++ b/src/pages/playground/getSRGBLuminanceFromRGB.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Get sRGB Luminance From RGB">
+  <script slot="script" is:inline type="module">
+    import { getSRGBLuminanceFromRGB } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const rgb = document.getElementById("input").value;
+      try {
+        const rgbObj = JSON.parse(rgb);
+        const res = getSRGBLuminanceFromRGB(rgbObj);
+        document.getElementById("result").innerHTML = res;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type an RGB object (e.g., {'{"r":34,"g":36,"b":41}'})</label>
+    <input type="text" id="input" class="input" placeholder='{"r":34,"g":36,"b":41}' />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/isCSSNamedDarkColour.astro
+++ b/src/pages/playground/isCSSNamedDarkColour.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Is CSS Named Dark Colour">
+  <script slot="script" is:inline type="module">
+    import { isCSSNamedDarkColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const name = document.getElementById("input").value;
+      try {
+        const res = isCSSNamedDarkColour(name);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = name;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type a named CSS colour</label>
+    <input type="text" id="input" class="input" placeholder="navy" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/isCSSRGBColour.astro
+++ b/src/pages/playground/isCSSRGBColour.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Is CSS RGB Colour">
+  <script slot="script" is:inline type="module">
+    import { isCSSRGBColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const cssRGB = document.getElementById("input").value;
+      try {
+        const res = isCSSRGBColour(cssRGB);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = cssRGB;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type a colour in the CSS RGB format</label>
+    <input type="text" id="input" class="input" placeholder="rgb(255, 224, 0)" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/isCSSRGBDarkColour.astro
+++ b/src/pages/playground/isCSSRGBDarkColour.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Is CSS RGB Dark Colour">
+  <script slot="script" is:inline type="module">
+    import { isCSSRGBDarkColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const cssRGB = document.getElementById("input").value;
+      try {
+        const res = isCSSRGBDarkColour(cssRGB);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = cssRGB;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type a colour in the CSS RGB format</label>
+    <input type="text" id="input" class="input" placeholder="rgb(34, 36, 41)" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/isDarkColour.astro
+++ b/src/pages/playground/isDarkColour.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Is Dark Colour">
+  <script slot="script" is:inline type="module">
+    import { isDarkColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const colour = document.getElementById("input").value;
+      try {
+        const res = isDarkColour(colour);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = colour;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type a colour (hexadecimal, RGB object, or CSS RGB)</label>
+    <input type="text" id="input" class="input" placeholder="#222429" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/isHexColour.astro
+++ b/src/pages/playground/isHexColour.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Is Hexadecimal Colour">
+  <script slot="script" is:inline type="module">
+    import { isHexColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const hex = document.getElementById("input").value;
+      try {
+        const res = isHexColour(hex);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = hex;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type a colour in the hexadecimal format</label>
+    <input type="text" id="input" class="input" placeholder="#ffe000" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>

--- a/src/pages/playground/isHexDarkColour.astro
+++ b/src/pages/playground/isHexDarkColour.astro
@@ -1,0 +1,26 @@
+---
+import PlaygroundLayout from "../../layouts/PlaygroundLayout.astro";
+---
+
+<PlaygroundLayout title="Is Hexadecimal Dark Colour">
+  <script slot="script" is:inline type="module">
+    import { isHexDarkColour } from "https://unpkg.com/@sardine/colour@2.4.0/dist/index.min.js";
+    function convertOnSubmit() {
+      const hex = document.getElementById("input").value;
+      try {
+        const res = isHexDarkColour(hex);
+        document.getElementById("result").innerHTML = res;
+        document.getElementById("result").style.backgroundColor = hex;
+      } catch (error) {
+        document.getElementById("result").innerHTML = error;
+      }
+    }
+    window.convertOnSubmit = convertOnSubmit;
+  </script>
+  <div slot="body">
+    <label for="input">Type a colour in the hexadecimal format</label>
+    <input type="text" id="input" class="input" placeholder="#222429" />
+    <button type="button" onclick="convertOnSubmit()">Convert</button>
+    <label id="result"></label>
+  </div>
+</PlaygroundLayout>


### PR DESCRIPTION
- Add documentation and playgrounds for:
  - isHexDarkColour
  - isHexColour
  - isDarkColour
  - isCSSRGBDarkColour
  - isCSSRGBColour
  - isCSSNamedDarkColour
  - getSRGBLuminanceFromRGB
  - getSRGBLuminanceFromHex
  - getContrastRatioFromNamedCSSColour
- Includes function signatures, examples, error handling, and interactive demos
- Follows documentation standards and style guide

Closes #68, #69, #70, #71, #72, #73, #74, #75, #76